### PR TITLE
Update Node version to LTS 18.16

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -2,7 +2,7 @@ pipeline:
   build:
     when:
       event: push
-    image: node:14.15-alpine
+    image: node:18.16-alpine
     commands:
       - npm ci
       - npm run build
@@ -11,7 +11,7 @@ pipeline:
     when:
       branch: master
       event: push
-    image: node:14.15-alpine
+    image: node:18.16-alpine
     secrets: ['npm_token']
     commands:
       - npm config set '//registry.npmjs.org/:_authToken' $NPM_TOKEN


### PR DESCRIPTION
Node 14 is EOL 30th of April 2023. This updates references to Node images < 14 to the LTS

[_Created by Sourcegraph batch change `rvu/node-14-eol`._](https://rvu.sourcegraph.com/organizations/rvu/batch-changes/node-14-eol)